### PR TITLE
Testing dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   "peerDependencies": {
     "leaflet": "^1.0.2",
     "prop-types": "^15.6.0",
-    "react": "^15.4.1",
-    "react-leaflet": "^1.0.1"
+    "react": "^16.3.2",
+    "react-leaflet": "^1.9.1"
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",
@@ -49,12 +49,12 @@
     "babel-preset-stage-0": "^6.1.18",
     "eslint": "^3.8.1",
     "eslint-plugin-react": "^6.4.1",
-    "leaflet": "^1.0.2",
+    "leaflet": "^1.3.1",
     "lodash.isequal": "^4.4.0",
     "prop-types": "^15.6.0",
     "react": "^15.4.1",
-    "react-dom": "^15.4.1",
-    "react-leaflet": "^1.0.1",
+    "react-dom": "^16.3.2",
+    "react-leaflet": "^1.9.1",
     "webpack": "^1.13.0",
     "webpack-dev-server": "^1.12.1"
   }


### PR DESCRIPTION
After changing the dependency versions from 15 to 16, I am able to install and use the example code in the latest react version.